### PR TITLE
fix visualization of synapses

### DIFF
--- a/src/neu3d.js
+++ b/src/neu3d.js
@@ -1490,7 +1490,7 @@ export class Neu3D {
    */
   onAddMesh(e) {
     if (!e.value['background']) {
-      if (!('morph_type' in e.value) || (e.value['morph_type'] != 'Synapse SWC'))
+      if (e.value['class'] == 'Neuron')
         ++this.uiVars.frontNum;
       this.groups.front.add(e.value.object);
     }
@@ -1519,7 +1519,7 @@ export class Neu3D {
       meshobj.children[j].material.dispose();
     }
     if (!e.value['background']) {
-      if (!('morph_type' in e.value) || (e.value['morph_type'] != 'Synapse SWC'))
+      if (e.value['class'] == 'Neuron')
         --this.uiVars.frontNum;
       this.groups.front.remove(meshobj);
     }
@@ -1655,8 +1655,7 @@ export class Neu3D {
   resetOpacity() {
     for (const key of Object.keys(this.meshDict)) {
       if (!this.meshDict[key]['background']) {
-        if (!('morph_type' in this.meshDict[key]) ||
-          (this.meshDict[key]['morph_type'] != 'Synapse SWC')) {
+        if (this.meshDict[key]['class'] == 'Neuron') {
           for (let i in this.meshDict[key].object.children) {
             if (this.meshDict[key]['opacity'] >= 0.) {
               this.meshDict[key].object.children[i].material.opacity = this.meshDict[key]['opacity'] * this.settings.defaultOpacity;

--- a/src/object_loader.js
+++ b/src/object_loader.js
@@ -50,7 +50,7 @@ Neu3D.prototype._registerObject = function (key, unit, object) {
     unit['position'] = new Vector3(0.5 * (unit.boundingBox.minX + unit.boundingBox.maxX), 0.5 * (unit.boundingBox.minY + unit.boundingBox.maxY), 0.5 * (unit.boundingBox.minZ + unit.boundingBox.maxZ));
   }
   // TODO: move the code below to a function
-  if (!('morph_type' in unit) || (unit['morph_type'] != 'Synapse SWC')) {
+  if (unit['class'] == 'Neuron') {
     if (unit['background']) {
       unit['object'].children[0].material.opacity = this.settings.backgroundOpacity;
       unit['object'].children[1].material.opacity = this.settings.backgroundWireframeOpacity;
@@ -399,9 +399,9 @@ Neu3D.prototype.loadMorphJSONCallBack = function (key, unit, visibility) {
       }
       this.updateObjectBoundingBox(unit, c.x, c.y, c.z);
       this.updateBoundingBox(c.x, c.y, c.z);
-      if ((c.parent != -1) && !(c.type == 7 || c.type == 8)) {
+      if (c.parent != -1) {
         let p = swcObj[c.parent];
-        if (this.settings.neuron3d) {
+        if (this.settings.neuron3d && unit['class'] == 'Neuron') {
           if (mergedGeometry == undefined) {
             mergedGeometry = new Geometry();
           }
@@ -462,7 +462,7 @@ Neu3D.prototype.loadMorphJSONCallBack = function (key, unit, visibility) {
         object.add(new Mesh(sphereGeometry, sphereMaterial));
         unit['position'] = new Vector3(c.x, c.y, c.z);
       }
-      if (c.type == 7 || c.type == 8) {
+      if (unit['class'] == 'Synapse') {
         console.debug('[Neu3D] Loading synapse node');
         if (this.settings.synapseMode == true){
           if(mergedGeometry == undefined)


### PR DESCRIPTION
Includes the following changes:
1: visualize synapse properly when 3D mode is on
2: adding synapses no longer add to the #Neurons count
3: identifier 7 and 8 in swc are no longer reserved only for synapses